### PR TITLE
fix:week8 調整留言板 Session 內容；修正 transaction 內容並確保其能運作

### DIFF
--- a/homeworks/week8/hw2/add_comments.php
+++ b/homeworks/week8/hw2/add_comments.php
@@ -1,34 +1,33 @@
 <?php
 	require_once('conn.php');
-	$tmpId = "";
-	if(isset($_COOKIE['tmpId'])){
-		$tmpId = $_COOKIE['tmpId'];
-	}
-	$contnet = $_POST['contnet'];
-	$sql = "";
-	$commentId = "";
-	if(isset($_POST['parentId']) && $_POST['parentId'] !== ""){
-		$parentId = $_POST['parentId'];
-		$stmt = $conn->prepare("INSERT INTO marin_comments (crt_user, contnet, parent_id) SELECT b.username AS crt_user, ? AS contnet, ? AS parent_id FROM marin_users_certificate a JOIN marin_users b ON a.username = b.username WHERE a.id = ?");
-		$stmt->bind_param("sis", $contnet, $parentId, $tmpId);
+	$result["rtnCde"] = "fail";
+	if(isset($_SESSION["userAccount"])){
+		$commentId = "";
+		$contnet = $_POST['contnet'];
+		if(isset($_POST['parentId']) && $_POST['parentId'] !== ""){
+			$parentId = $_POST['parentId'];
+			$stmt = $conn->prepare("INSERT INTO marin_comments (crt_user, contnet, parent_id) VALUES (?, ?, ?)");
+			$stmt->bind_param("ssi", $_SESSION["userAccount"], $contnet, $parentId);
+			$stmt->execute();
+			$commentId = $stmt->insert_id;
+			$stmt->close();
+		}
+		else{
+			$stmt = $conn->prepare("INSERT INTO marin_comments (crt_user, contnet) VALUES (?, ?)");
+			$stmt->bind_param("ss", $_SESSION["userAccount"], $contnet);
+			$stmt->execute();
+			$commentId = $stmt->insert_id;
+			$stmt->close();
+		}
+
+		$stmt = $conn->prepare("SELECT * FROM marin_comments a WHERE a.id = ?");
+		$stmt->bind_param("i", $commentId);
 		$stmt->execute();
-		$commentId = $stmt->insert_id;
+		$sqlResult = $stmt->get_result();
+		$result = $sqlResult->fetch_assoc();
 		$stmt->close();
+		$result["rtnCde"] = "success";
 	}
-	else{
-		$stmt = $conn->prepare("INSERT INTO marin_comments (crt_user, contnet) SELECT b.username AS crt_user, ? AS contnet FROM marin_users_certificate a JOIN marin_users b ON a.username = b.username WHERE a.id = ?");
-		$stmt->bind_param("ss", $contnet, $tmpId);
-		$stmt->execute();
-		$commentId = $stmt->insert_id;
-		$stmt->close();
-	}
-	$stmt = $conn->prepare("SELECT * FROM marin_comments a WHERE a.id = ?");
-	$stmt->bind_param("i", $commentId);
-	$stmt->execute();
-	$sqlResult = $stmt->get_result();
-	$result = $sqlResult->fetch_assoc();
-	$stmt->close();
 	$conn->close();
-	$result["rtnCde"] = "success";
 	echo json_encode($result);
 ?>

--- a/homeworks/week8/hw2/add_users.php
+++ b/homeworks/week8/hw2/add_users.php
@@ -6,15 +6,10 @@
 	$stmt = $conn->prepare("INSERT INTO marin_users (username, password, nickname) VALUES (?, ?, ?)");
 	$stmt->bind_param("sss", $userAccount, $password, $nickname);
 	if($stmt->execute()){
-		$tmpId = password_hash(uniqid(rand(mt_srand((double)microtime()*10000)), true), PASSWORD_DEFAULT);
 
-		// 新增新的 session id
-		$stmt = $conn->prepare("INSERT INTO marin_users_certificate (id, username) VALUES (?, ?)");
-		$stmt->bind_param("ss", $tmpId, $userAccount);
-		$stmt->execute();
-		$stmt->close();
+		$_SESSION["userAccount"] = $userAccount;
+		$_SESSION["nickname"] = (!isset($nickname) || $nickname === "") ? $userAccount : $nickname;
 
-		$_SESSION["tmpId"] = $tmpId;
 		header('Location: index.php');
 	}
 	else{

--- a/homeworks/week8/hw2/del_comments.php
+++ b/homeworks/week8/hw2/del_comments.php
@@ -1,28 +1,31 @@
 <?php
 	require_once('conn.php');
-	$tmpId = $_COOKIE["tmpId"];
-	$postId = $_POST['commentId'];
+	
+	$result = null;
 	$rtnCde = "success";
 
-	$stmt = $conn->prepare("SELECT c.id FROM marin_users_certificate a JOIN marin_users b ON a.username = b.username JOIN marin_comments c ON c.crt_user = b.username AND c.id = ?  WHERE a.id = ?");
-	$stmt->bind_param("is", $postId, $tmpId);
+	if(isset($_SESSION["userAccount"])){
+		$postId = $_POST['commentId'];
+		$stmt = $conn->prepare("SELECT c.id FROM marin_comments c WHERE c.crt_user = ? AND c.id = ?");
+		$stmt->bind_param("si", $_SESSION["userAccount"], $postId);
 
-	if($stmt->execute()){
-		$certificate = $stmt->get_result();
-		$stmt->close();
+		if($stmt->execute()){
+			$certificate = $stmt->get_result();
+			$stmt->close();
 
-		$certificateRow = $certificate->fetch_assoc();
-		$commentId = $certificateRow['id'];
-		$stmt = $conn->prepare("DELETE FROM marin_comments WHERE id = ? OR parent_id = ?");
-		$stmt->bind_param("ii", $commentId, $commentId);
-		if(!$stmt->execute()){
+			$certificateRow = $certificate->fetch_assoc();
+			$commentId = $certificateRow['id'];
+			$stmt = $conn->prepare("DELETE FROM marin_comments WHERE id = ? OR parent_id = ?");
+			$stmt->bind_param("ii", $commentId, $commentId);
+			if(!$stmt->execute()){
+				$rtnCde = "fail";
+			}
+			$stmt->close();
+		}
+		else{
+			$stmt->close();
 			$rtnCde = "fail";
 		}
-		$stmt->close();
-	}
-	else{
-		$stmt->close();
-		$rtnCde = "fail";
 	}
 	$conn->close();
 

--- a/homeworks/week8/hw2/edit_comments.php
+++ b/homeworks/week8/hw2/edit_comments.php
@@ -1,24 +1,25 @@
 <?php
 	require_once('conn.php');
-	$tmpId = $_COOKIE["tmpId"];
-	$postId = $_POST['commentId'];
+	
+	if(isset($_SESSION["userAccount"])){
+		$postId = $_POST['commentId'];
+		$stmt = $conn->prepare("SELECT c.id FROM marin_comments c WHERE c.crt_user = ? AND c.id = ?");
+			$stmt->bind_param("si", $_SESSION["userAccount"], $postId);
+		if($stmt->execute()){
+			$certificate = $stmt->get_result();
+			$stmt->close();
 
-	$stmt = $conn->prepare("SELECT c.id FROM marin_users_certificate a JOIN marin_users b ON a.username = b.username JOIN marin_comments c ON c.crt_user = b.username AND c.id = ?  WHERE a.id = ?");
-	$stmt->bind_param("is", $postId, $tmpId);
-	if($stmt->execute()){
-		$certificate = $stmt->get_result();
-		$stmt->close();
-
-		$certificateRow = $certificate->fetch_assoc();
-		$commentId = $certificateRow['id'];
-		$contnet = $_POST['contnet'];
-		$stmt = $conn->prepare("UPDATE marin_comments SET contnet = ? WHERE id = ?");
-		$stmt->bind_param("si", $contnet, $commentId);
-		$stmt->execute();
-		$stmt->close();
-	}
-	else{
-		$stmt->close();
+			$certificateRow = $certificate->fetch_assoc();
+			$commentId = $certificateRow['id'];
+			$contnet = $_POST['contnet'];
+			$stmt = $conn->prepare("UPDATE marin_comments SET contnet = ? WHERE id = ?");
+			$stmt->bind_param("si", $contnet, $commentId);
+			$stmt->execute();
+			$stmt->close();
+		}
+		else{
+			$stmt->close();
+		}
 	}
 	$conn->close();
 

--- a/homeworks/week8/hw2/get_comments.php
+++ b/homeworks/week8/hw2/get_comments.php
@@ -24,7 +24,7 @@
 			<div class="main__post__comment--text">
 				<?php echo htmlspecialchars($row['contnet']); ?>
 			</div>
-			<?php if($row['crt_user'] === $userAccount){ ?>
+			<?php if(isset($_SESSION["userAccount"]) && $row['crt_user'] === $_SESSION["userAccount"]){ ?>
 				<div class="postAction">
 					<div class="postAction__edit wt-90">
 						<form action="edit_comments.php" method="POST">
@@ -58,7 +58,7 @@
 						<div class="main__subpost__info--time"><?php echo $subRow['crt_time']; ?></div>
 					</div>
 					<div class="main__subpost__comment--text"><?php echo htmlspecialchars($subRow['contnet']); ?></div>
-					<?php if($subRow['crt_user'] === $userAccount){ ?>
+					<?php if(isset($_SESSION["userAccount"]) && $subRow['crt_user'] === $_SESSION["userAccount"]){ ?>
 						<div class="postAction">
 							<div class="postAction__edit wt-100">
 								<form action="edit_comments.php" method="POST">
@@ -83,16 +83,18 @@
 			?>
 			<div class="main__post__subfrom" style="display: none;">
 				<div class="main__post__subfrom--nickname">
-					<?php echo $userAccount === "" ? "請先登入" : $nickname; ?>
+					<?php echo isset($_SESSION["userAccount"]) ? $_SESSION["nickname"] : "請先登入"; ?>
 				</div>
 				<div>
 					<textarea class="main__post__subfrom--textarea wt-90 margin-bot-10" name="contnet" placeholder="留言內容"></textarea>
 				</div>
 				<div>
 					<?php 
-						if($userAccount === "") {
+						if(!isset($_SESSION["userAccount"])) {
 					?>
-							<input class="btn btn-primary btn-lg" type="button" disabled="true" value="請先登入" />
+							<a href="login.php">
+								<input class="btn btn-primary btn-lg" type="button" value="請先登入" />
+							</a>
 					<?php
 						} else {
 					?>

--- a/homeworks/week8/hw2/index.php
+++ b/homeworks/week8/hw2/index.php
@@ -12,22 +12,6 @@
 
 	<?php 
 		require_once('conn.php');
-		$userAccount = null;
-		$nickname = null;
-		if(isset($_SESSION["tmpId"])) {
-			$tmpId = $_SESSION["tmpId"];
-			$stmt = $conn->prepare("SELECT b.* FROM marin_users_certificate a JOIN marin_users b ON a.username = b.username WHERE a.id = ?");
-			$stmt->bind_param("s", $tmpId);
-			$stmt->execute();
-			$certificate = $stmt->get_result();
-			$stmt->close();
-			if($certificate->num_rows === 1){
-				while($certificateRow = $certificate->fetch_assoc()) {
-					$userAccount = $certificateRow['username'];
-					$nickname = $certificateRow['nickname'] === "" ? $userAccount : $certificateRow['nickname'];
-				}
-			}
-		}
 	?>
 </head>
 
@@ -37,7 +21,7 @@
 	<header>
 		<nav class="navbar navbar-expand navbar-dark fixed-top bg-dark">
 			<ul class="navbar-nav">
-			<?php if($userAccount === "") {?>
+			<?php if(!isset($_SESSION["userAccount"])) {?>
 				<li class="nav-item active">
 					<a class="nav-link" href="login.php">登入</a>
 				</li>
@@ -66,14 +50,16 @@
 		<div class="row">
 			<div class="main__from col div-border">
 				<div class="main__nickname">
-					<?php echo $userAccount === "" ? "請先登入" : $nickname; ?>
+					<?php echo isset($_SESSION["userAccount"]) ? $_SESSION["nickname"] : "請先登入"; ?>
 				</div>
 				<div>
 					<textarea class="wt-100" name="contnet" placeholder="留言內容"></textarea>
 				</div>
 				<div>
-				<?php if($userAccount === "") {?>
-					<input class="btn btn-primary btn-lg" type="button" disabled value="請先登入" />
+				<?php if(!isset($_SESSION["userAccount"])) {?>
+					<a href="login.php">
+						<input class="btn btn-primary btn-lg" type="button" value="請先登入" />
+					</a>
 				<?php } else { ?>
 					<input class="btn btn-primary btn-lg" type="button" value="留言">
 				<?php }?>

--- a/homeworks/week8/hw2/login.php
+++ b/homeworks/week8/hw2/login.php
@@ -19,22 +19,9 @@
 			$dbPassword = $row['password'];
 			if(password_verify($password, $dbPassword)){
 
-				$tmpId = password_hash(uniqid(rand(mt_srand((double)microtime()*10000)), true), PASSWORD_DEFAULT);
-				$username = $row['username'];
+				$_SESSION["userAccount"] = $row['username'];
+				$_SESSION["nickname"] = (!isset($row['nickname']) || $row['nickname'] === "") ? $row['username'] : $row['nickname'];
 
-				// 先刪除舊有的 session id
-				$stmt = $conn->prepare("DELETE FROM marin_users_certificate WHERE username = ?");
-				$stmt->bind_param("s", $username);
-				$stmt->execute();
-				$stmt->close();
-
-				// 再新增新的 session id
-				$stmt = $conn->prepare("INSERT INTO marin_users_certificate (id, username) VALUES (?, ?)");
-				$stmt->bind_param("ss", $tmpId, $username);
-				$stmt->execute();
-				$stmt->close();
-
-				$_SESSION["tmpId"] = $tmpId;
 				header('Location: index.php');
 			}
 			else{

--- a/homeworks/week8/hw2/logout.php
+++ b/homeworks/week8/hw2/logout.php
@@ -1,5 +1,6 @@
 <?php
 	session_start();
+	session_unset();
 	session_destroy();
 	header('Location: index.php');
 ?>


### PR DESCRIPTION
### 原先問題
1. PHP 原始 SESSION 機制沒弄清楚。[ 已解決 ]
2. transaction 沒有正確將資料鎖住，還是會有超賣問題。[ 已解決 ]

### 測試過程額外發現問題
如果發生多筆的搶購狀況，可能會出現 SELECT 語法鎖死問題。
錯誤訊息 : Deadlock found when trying to get lock; try restarting transaction。

### 案例說明
同時發生 transaction A, B
transaction A 按照訂購順序依序鎖住代號為 [1, 5, 7] 的商品。
transaction B 按照訂購順序依序鎖住代號為 [7, 5, 1] 的商品。
此時 transaction B 在 SELECT 語法要執行時會發生上述錯誤。

### 解決方式 ( 程式尚未處理該問題，但已有解題方向。)
將要發送的訂單明細依商品代號先排序，即可避免此問題。
參考資料來源 : https://stackoverflow.com/questions/2332768/how-to-avoid-mysql-deadlock-found-when-trying-to-get-lock-try-restarting-trans

